### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/837/7/1141908377.geojson
+++ b/data/114/190/837/7/1141908377.geojson
@@ -30,6 +30,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0631\u064a\u062a\u0641\u064a\u0643\u0646"
     ],
+    "name:ara_x_variant":[
+        "\u063a\u0631\u064a\u062a\u0641\u064a\u0643\u0646"
+    ],
     "name:aze_x_preferred":[
         "Qryotviken"
     ],
@@ -73,6 +76,9 @@
         "Grytviken"
     ],
     "name:est_x_preferred":[
+        "Grytviken"
+    ],
+    "name:eus_x_preferred":[
         "Grytviken"
     ],
     "name:fas_x_preferred":[
@@ -374,7 +380,7 @@
         }
     ],
     "wof:id":1141908377,
-    "wof:lastmodified":1636503123,
+    "wof:lastmodified":1690927550,
     "wof:name":"Grytviken",
     "wof:parent_id":85681367,
     "wof:placetype":"locality",

--- a/data/421/177/465/421177465.geojson
+++ b/data/421/177/465/421177465.geojson
@@ -20,6 +20,12 @@
     "name:ang_x_preferred":[
         "Stromn\u00e6ss"
     ],
+    "name:ara_x_preferred":[
+        "\u0633\u062a\u0631\u0648\u0645\u0646\u064a\u0633"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u062a\u0631\u0648\u0645\u0646\u064a\u0633"
+    ],
     "name:deu_x_preferred":[
         "Stromness"
     ],
@@ -100,7 +106,7 @@
         }
     ],
     "wof:id":421177465,
-    "wof:lastmodified":1566642503,
+    "wof:lastmodified":1690927550,
     "wof:name":"Stromness",
     "wof:parent_id":85681367,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.